### PR TITLE
Check for last page

### DIFF
--- a/djangular-rest-framework.js
+++ b/djangular-rest-framework.js
@@ -36,7 +36,7 @@
                         deferred.update(data);
                         items = items.concat(data);
 
-                        if (angular.isDefined(response.data.next) && items.length < options.limit) {
+                        if (isDefined(response.data.next) && response.data.next !== null && items.length < options.limit) {
                             api.getPage(response.data.next, options, deferred, items);
                         } else {
                             if (isDefined(options.limit)) {


### PR DESCRIPTION
The `next` key does not disappear from the last page's response so check if it's `null`.
