### PR TITLE
Base undefined limit on response

### DIFF
--- a/djangular-rest-framework.js
+++ b/djangular-rest-framework.js
@@ -33,6 +33,10 @@
                             data = response.data;
                         }
 
+                        if (angular.isDefined(response.data.count) && angular.isUndefined(options.limit)) {
+                            options.limit = response.data.count;
+                        }
+
                         deferred.update(data);
                         items = items.concat(data);
 


### PR DESCRIPTION
If the limit option hasn't been set use the count returned by DRF to set
this variable.
