### PR TITLE
Remove the cache from loadOptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.0.2
+
+* Remove cache from `loadOptions`. The cache stopped the response from the server
+ being resolved.
+
 # 4.0.1
 
 * Update the main property in `bower.json`.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "djangular-rest-framework",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "homepage": "https://github.com/incuna/djangular-rest-framework",
   "authors": [
     "Marc Tamlyn <marc.tamlyn@gmail.com>",

--- a/src/djangular-rest-framework.js
+++ b/src/djangular-rest-framework.js
@@ -263,27 +263,10 @@
                     options = angular.extend({}, defaultOptions, options);
                     deferred = deferred || extQ.defer();
 
-                    var cachedObject;
-                    if (cacheEnabled && options.cacheItems) {
-                        $timeout(function () {
-                            // Load the options from the cache.
-                            cachedObject = api.optionsCache.get(url);
-                            if (angular.isDefined(cachedObject)) {
-                                deferred.resolve({data: cachedObject, url: url});
-                            }
-                        }, 0);
-                    }
-
                     $http({
                         method: 'OPTIONS',
                         url: url
                     }).then(function (response) {
-                        if (cacheEnabled && options.cacheItems) {
-                            if (!angular.equals(cachedObject, response.data)) {
-                                api.optionsCache.put(url, response.data);
-                            }
-                        }
-
                         deferred.resolve({data: response.data, url: url});
                     }, deferred.reject);
 


### PR DESCRIPTION
The cache was causing the 'actual' response from the server to be
ignored because the promise had already been resolved (with the cached
version).
